### PR TITLE
bootstrap(liquidation): use latest images for initial Argo sync

### DIFF
--- a/apps/liquidation/base/backend-deployment.yml
+++ b/apps/liquidation/base/backend-deployment.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: your-dockerhub-username/liquidation-calculator-backend:latest # Go backend image built via CI
+        image: volumegambit/liquidation-calculator-backend:latest # Go backend image built via CI
         ports:
         - containerPort: 5001
         envFrom:

--- a/apps/liquidation/base/frontend-deployment.yml
+++ b/apps/liquidation/base/frontend-deployment.yml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: your-dockerhub-username/liquidation-calculator-frontend:latest # Replace with your Docker Hub username
+        image: volumegambit/liquidation-calculator-frontend:latest # Replace with your Docker Hub username
         ports:
         - containerPort: 80


### PR DESCRIPTION
Set Docker images to volumegambit/*:latest for initial deployment; subsequent runs will bump to SHA tags via CI.