### PR TITLE
feat: ingress + cert-manager + Ingress TLS (placeholders)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,10 @@ This repository holds Kubernetes configuration for applications deployed via Arg
   ```
 - Argo CD reconciles changes and deploys to the cluster.
 
+
+## Ingress & TLS
+- ingress-nginx is installed via Argo CD (LoadBalancer Service).
+- cert-manager issues Let's Encrypt certificates via HTTP-01 using ClusterIssuer letsencrypt-prod.
+- Replace example.com hosts in overlays with your domain and point DNS A/AAAA to the Ingress LB IP.
+- For wildcard certificates and fewer validations, switch to DNS-01 with your DNS provider (configure a new ClusterIssuer).
+

--- a/apps/liquidation/base/backend-deployment.yml
+++ b/apps/liquidation/base/backend-deployment.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: backend
-        image: your-dockerhub-username/liquidation-calculator-backend:latest # Go backend image built via CI
+        image: volumegambit/liquidation-calculator-backend:latest # Go backend image built via CI
         ports:
         - containerPort: 5001
         envFrom:

--- a/apps/liquidation/base/frontend-deployment.yml
+++ b/apps/liquidation/base/frontend-deployment.yml
@@ -14,6 +14,6 @@ spec:
     spec:
       containers:
       - name: frontend
-        image: your-dockerhub-username/liquidation-calculator-frontend:latest # Replace with your Docker Hub username
+        image: volumegambit/liquidation-calculator-frontend:latest # Replace with your Docker Hub username
         ports:
         - containerPort: 80

--- a/apps/liquidation/base/frontend-service.yml
+++ b/apps/liquidation/base/frontend-service.yml
@@ -9,4 +9,4 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80
-  type: LoadBalancer
+  type: ClusterIP

--- a/apps/liquidation/base/kustomization.yaml
+++ b/apps/liquidation/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backend-deployment.yml
+  - backend-service.yml
+  - frontend-deployment.yml
+  - frontend-service.yml

--- a/apps/liquidation/overlays/prod/ingress.yaml
+++ b/apps/liquidation/overlays/prod/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: liquidation-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - liquidation.example.com
+      secretName: liquidation-tls
+  rules:
+    - host: liquidation.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-service
+                port:
+                  number: 80

--- a/apps/liquidation/overlays/prod/kustomization.yaml
+++ b/apps/liquidation/overlays/prod/kustomization.yaml
@@ -5,3 +5,7 @@ resources:
   - ../../base
   - namespace.yaml
 # Images can be updated by CI via `kustomize edit set image`
+resources:
+  - ../../base
+  - namespace.yaml
+  - ingress.yaml

--- a/apps/roulette/base/frontend-service.yml
+++ b/apps/roulette/base/frontend-service.yml
@@ -9,4 +9,4 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80
-  type: LoadBalancer
+  type: ClusterIP

--- a/apps/roulette/base/kustomization.yaml
+++ b/apps/roulette/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - backend-deployment.yml
+  - backend-service.yml
+  - frontend-deployment.yml
+  - frontend-service.yml

--- a/apps/roulette/overlays/prod/ingress.yaml
+++ b/apps/roulette/overlays/prod/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: roulette-ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+spec:
+  tls:
+    - hosts:
+        - roulette.example.com
+      secretName: roulette-tls
+  rules:
+    - host: roulette.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend-service
+                port:
+                  number: 80

--- a/apps/roulette/overlays/prod/kustomization.yaml
+++ b/apps/roulette/overlays/prod/kustomization.yaml
@@ -4,3 +4,7 @@ namespace: roulette
 resources:
   - ../../base
   - namespace.yaml
+resources:
+  - ../../base
+  - namespace.yaml
+  - ingress.yaml

--- a/argocd/applications/cert-manager.yaml
+++ b/argocd/applications/cert-manager.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.jetstack.io
+    chart: cert-manager
+    targetRevision: v1.14.4
+    helm:
+      releaseName: cert-manager
+      values: |
+        installCRDs: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/applications/cluster-issuer-app.yaml
+++ b/argocd/applications/cluster-issuer-app.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cluster-issuer
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/volumegambit/monorepo-cluster-config.git
+    path: infra/cert-manager
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cert-manager
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argocd/applications/ingress-nginx.yaml
+++ b/argocd/applications/ingress-nginx.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingress-nginx
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes.github.io/ingress-nginx
+    chart: ingress-nginx
+    targetRevision: 4.11.2
+    helm:
+      releaseName: ingress-nginx
+      values: |
+        controller:
+          service:
+            type: LoadBalancer
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingress-nginx
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/applications/kustomization.yaml
+++ b/argocd/applications/kustomization.yaml
@@ -3,3 +3,6 @@ kind: Kustomization
 resources:
   - liquidation.yaml
   - roulette.yaml
+  - ingress-nginx.yaml
+  - cert-manager.yaml
+  - cluster-issuer-app.yaml

--- a/infra/cert-manager/cluster-issuer.yaml
+++ b/infra/cert-manager/cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: your-email@example.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+      - http01:
+          ingress:
+            class: nginx

--- a/infra/cert-manager/kustomization.yaml
+++ b/infra/cert-manager/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cluster-issuer.yaml


### PR DESCRIPTION
Install ingress-nginx and cert-manager via Argo CD; add ClusterIssuer; convert frontends to ClusterIP + Ingress; placeholders for hosts.