### PR TITLE
feat(ingress): use volumegambit.com hosts

### DIFF
--- a/apps/liquidation/overlays/prod/ingress.yaml
+++ b/apps/liquidation/overlays/prod/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - liquidation.example.com
+        - liquidation.volumegambit.com
       secretName: liquidation-tls
   rules:
-    - host: liquidation.example.com
+    - host: liquidation.volumegambit.com
       http:
         paths:
           - path: /

--- a/apps/roulette/overlays/prod/ingress.yaml
+++ b/apps/roulette/overlays/prod/ingress.yaml
@@ -9,10 +9,10 @@ metadata:
 spec:
   tls:
     - hosts:
-        - roulette.example.com
+        - roulette.volumegambit.com
       secretName: roulette-tls
   rules:
-    - host: roulette.example.com
+    - host: roulette.volumegambit.com
       http:
         paths:
           - path: /


### PR DESCRIPTION
Update Ingress hosts to liquidation.volumegambit.com and roulette.volumegambit.com for TLS issuance.